### PR TITLE
Feat: 로그인 정보에 따른 헤더 변경 제작

### DIFF
--- a/src/components/header.ts
+++ b/src/components/header.ts
@@ -15,21 +15,27 @@ class HeaderComponent extends HTMLElement {
 
   // 프레임워크 메서드
   render() {
+    const token = sessionStorage.getItem('accessToken');
     // 유저 로그인 유/무에 따른 헤더 모양 변화를 위한 함수 호출
     // const user = this.getUser();
     this.innerHTML = `<div class="header">
       <a href="/"><img class="logo" src="${homeLogo}" alt="로고" /></a>
-      <div class="bundle">
-        <!-- 사용자 로그인시 나올 종 -->
-        <!-- <img class="bell" src="${bell}" alt="종 아이콘" /> -->
-        <a href="/src/search/search.html"><img class="search" src="${search}" alt="검색 아이콘" /></a>
-
-        <!-- 사용자 미로그인시 나올 버튼-->
-        <a class="start-btn" href="/src/sign-up/login.html">시작하기</a>
-
-        <!-- 사용자 로그인시 나올 프로필 사진 -->
-        <!-- <img class="profile" src="${profile}" alt="사용자 프로필" /> -->
-      </div>
+      ${
+        token
+          ? `
+          <div class="bundle">
+            <img class="bell" src="${bell}" alt="종 아이콘" />
+            <a href="/src/search/search.html"><img class="search" src="${search}" alt="검색 아이콘" /></a>
+            <img class="profile" src="${profile}" alt="사용자 프로필" />
+          </div>
+          `
+          : `
+          <div class="bundle">
+            <a href="/src/search/search.html"><img class="search" src="${search}" alt="검색 아이콘" /></a>
+            <a class="start-btn" href="/src/sign-up/login.html">시작하기</a>
+          </div>
+          `
+      }
     </div>`;
   }
 

--- a/src/sign-up/login.ts
+++ b/src/sign-up/login.ts
@@ -1,3 +1,20 @@
+/*
+간편 로그인을 하는 경우 로그인 타입이 바뀐다
+
+token 속성
+accessToken = 만료 기간을 정하는 토큰(일정 시간을 정해서 보내면 일정 시간 후 만료)
+refreshToken = 만료 기간을 갱신하는 토큰(새로운 토큰을 발급)
+
+accessToken을 sessionStorage에 저장(그렇게 어렵지 않다)
+로그인이 필요한 기능 -> accessToken이 필요
+-> accessToken을 가져가서 사용하는 구조로 변경하면 된다.(token 유무로 페이지 구분)
+
+refreschToken은 에러를 기준으로 작업한다.
+-> accessToken에 비해 난이도가 있다.
+
+http only cookie = 서버쪽에서만 접근 가능(현재는 이 방식을 주로 사용)
+*/
+
 import { getAxios } from '../utils/axios';
 
 interface User {
@@ -19,10 +36,13 @@ async function onLogin() {
   const password = passwordInput.value.trim();
 
   try {
-    const response = await axios.post<User>(`/users/login`, { email, password });
+    const response = await axios.post(`/users/login?expiresln=1d`, { email, password });
     const user = response.data;
+    const accessToken = user.item.token.accessToken;
+    sessionStorage.setItem('accessToken', accessToken);
+
     console.log('로그인 성공: ', user);
-    location.href = '../main-page/main-page.html';
+    location.href = '/';
   } catch (err) {
     console.log(err);
     alert('아이디와 비밀번호를 확인해주세요.');


### PR DESCRIPTION
Modify: login.ts 토큰 sessionStorage 저장 코드 추가 #17

## PR 유형

<!-- PR 내용에 대한 유형을 적어주세요. -->
<!-- 예시: - [] 기능 추가 -->

- [x] 로그인 정보에 따른 헤더 노출 변경 기능 추가

## 반영 브랜치

<!-- 작업한 브랜치 -> 반영할 브랜치로 적어주세요. -->
<!-- 예시: 작업한 브랜치 -> 반영할 브랜치 -->

- feature/mainPage -> develop

## 기능 사항

<!-- 추가 및 수정된 사항을 적어주세요. -->
<!-- 예시: button을 눌렀을 시 로그인 화면으로 이동 -->

- 로그인 화면에서 정보를 입력 후 로그인 버튼 클릭 시 sessionStorage를 활용하여 token을 저장
- 저장한 토큰의 유무에 따라 메인 페이지 헤더의 노출 항목을 변경

## 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 예시 : #이슈 번호 -->

- #17 

## Etc.
- sessionStorage 작업을 원래대로라면 feature/signUp 브랜치에서 진행하는게 맞다고 판단하였으나, 이를 인지하지 못하고 feature/mainPage 브랜치에서 작업을 진행했음
- login.ts에서 /user/login?expiresln=1d를 통해 토큰 만료기간은 임의로 1일로 지정하였음
